### PR TITLE
Change default credentials option to 'same-origin'

### DIFF
--- a/src/handlers/http.js
+++ b/src/handlers/http.js
@@ -7,7 +7,7 @@ const defaultHeaders = {
 function httpGetFn(get, { url, headers, options }) {
   const defaultOptions = {
     method: "GET",
-    credentials: "include"
+    credentials: "same-origin"
   };
   const allOptions = Object.assign({}, defaultOptions, options, { headers });
   return get(url, allOptions)
@@ -18,7 +18,7 @@ function httpGetFn(get, { url, headers, options }) {
 function httpDeleteFn(remove, { url, headers, options }) {
   const defaultOptions = {
     method: "DELETE",
-    credentials: "include"
+    credentials: "same-origin"
   };
   const allOptions = Object.assign({}, defaultOptions, options, { headers });
   return remove(url, allOptions)
@@ -29,7 +29,7 @@ function httpDeleteFn(remove, { url, headers, options }) {
 function httpPostFn(post, { url, payload, headers, options }) {
   const defaultOptions = {
     method: "POST",
-    credentials: "include",
+    credentials: "same-origin",
     body: JSON.stringify(payload),
     headers: defaultHeaders
   };
@@ -45,7 +45,7 @@ function httpPostFn(post, { url, payload, headers, options }) {
 function httpPutFn(put, { url, payload, headers, options }) {
   const defaultOptions = {
     method: "PUT",
-    credentials: "include",
+    credentials: "same-origin",
     body: JSON.stringify(payload),
     headers: defaultHeaders
   };


### PR DESCRIPTION
What do you think about changing the default credentials to same-origin? It'll still send cookies on the same-origin and it has the added benefit of working with CORS servers.

CORS APIs are set to `allow-origin: *` which will reject any request with credentials attached. So if we switch the default to `same-origin` we can have the best of both worlds without having to add extra parameters onto the httpGet command.

Otherwise I have to do this and it's uglier: 😅

```javascript
const user = yield cmds.httpGet(
  `https://api.github.com/users/tylerbuchea`,
  {},
  { credentials: 'same-origin' }
);
```

Reference:

[https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials)

Here is the error I was getting:

<img width="1437" alt="screen shot 2017-10-18 at 9 43 54 am" src="https://user-images.githubusercontent.com/1241700/31732291-e48113e8-b3ec-11e7-8777-4137b7135915.png">
